### PR TITLE
Fix Instagram and add Glui image loading

### DIFF
--- a/qml/tweetian-harmattan/TweetPageJS.js
+++ b/qml/tweetian-harmattan/TweetPageJS.js
@@ -129,6 +129,16 @@ var PIC_SERVICES = [
         }
     },
     {
+        regexp: /http:\/\/glui\.me\/\?i=\w+\/[^"/]+\//ig,
+        getPicUrl: function(link) {
+            link = link.replace(/\/+$/, '') // remove trailing slashes
+            link = link.replace(/_/g, "%20") // replace all _ with %20
+            link = link.replace("://glui.me/?i=", "://dl.dropboxusercontent.com/s/")
+            var url = { full: link, thumb: link }
+            return url
+        }
+    },
+    {
         regexp: /https?:\/\/[^"]+?\.(?:jpe?g|png|gif)(?=")/gi,
         getPicUrl: function (link) { return { full: link, thumb: link }; }
     }

--- a/qml/tweetian-harmattan/TweetPageJS.js
+++ b/qml/tweetian-harmattan/TweetPageJS.js
@@ -43,8 +43,9 @@ var PIC_SERVICES = [
         }
     },
     {
-        regexp: /http:\/\/instagram.com\/p\/[^\/]+\//ig,
+        regexp: /http:\/\/instagram\.com\/p\/[^"]+/ig,
         getPicUrl: function(link) {
+            link = link.replace(/\/?$/, '/') // ensure a trailing slash
             var url = {
                 full: link + "media/?size=l",
                 thumb: link + "media/?size=t"

--- a/qml/tweetian-symbian/TweetPageJS.js
+++ b/qml/tweetian-symbian/TweetPageJS.js
@@ -129,7 +129,7 @@ var PIC_SERVICES = [
         }
     },
     {
-        regexp: /http:\/\/glui\.me\/\?i=\w+/ig,
+        regexp: /http:\/\/glui\.me\/\?i=\w+\/[^"/]+\//ig,
         getPicUrl: function(link) {
             link = link.replace(/\/+$/, '') // remove trailing slashes
             link = link.replace(/_/g, "%20") // replace all _ with %20

--- a/qml/tweetian-symbian/TweetPageJS.js
+++ b/qml/tweetian-symbian/TweetPageJS.js
@@ -128,6 +128,16 @@ var PIC_SERVICES = [
         }
     },
     {
+        regexp: /http:\/\/glui\.me\/\?i=\w+/ig,
+        getPicUrl: function(link) {
+            link = link.replace(/\/+$/, '') // remove trailing slashes
+            link = link.replace(/_/g, "%20") // replace all _ with %20
+            link = link.replace("://glui.me/?i=", "://dl.dropboxusercontent.com/s/")
+            var url = { full: link, thumb: link }
+            return url
+        }
+    },
+    {
         regexp: /https?:\/\/[^"]+?\.(?:jpe?g|png|gif)(?=")/gi,
         getPicUrl: function (link) { return { full: link, thumb: link }; }
     }

--- a/qml/tweetian-symbian/TweetPageJS.js
+++ b/qml/tweetian-symbian/TweetPageJS.js
@@ -43,7 +43,7 @@ var PIC_SERVICES = [
         }
     },
     {
-        regexp: /http:\/\/instagram\.com\/p\/[^\/]+\//ig,
+        regexp: /http:\/\/instagram\.com\/p\/[^"]+/ig,
         getPicUrl: function(link) {
             link = link.replace(/\/?$/, '/') // ensure a trailing slash
             var url = {

--- a/qml/tweetian-symbian/TweetPageJS.js
+++ b/qml/tweetian-symbian/TweetPageJS.js
@@ -43,8 +43,9 @@ var PIC_SERVICES = [
         }
     },
     {
-        regexp: /http:\/\/instagram.com\/p\/[^\/]+\//ig,
+        regexp: /http:\/\/instagram\.com\/p\/[^\/]+\//ig,
         getPicUrl: function(link) {
+            link = link.replace(/\/?$/, '/') // ensure a trailing slash
             var url = {
                 full: link + "media/?size=l",
                 thumb: link + "media/?size=t"


### PR DESCRIPTION
Images shared with Instagram nearly always end with a slash (when shared via the client), but of course it's possible for someone to copy and paste one without (e.g. http://instagram.com/p/j4k_ZioaCo) as NASA recently did (https://twitter.com/NASA/status/429688471423156225) which was spread far and wide. 

URLs without trailing slashes weren't showing the images. Here's a fix.

Also, I've added image loading for glui.me URLs. Glui is a Mac app for easily sharing (and annotating) screenshots via Dropbox. For example, the code now changes:
http://glui.me/?i=98tadpgxfk2zudn/2014-02-01_at_16.20.png/
into:
http://dl.dropboxusercontent.com/s/98tadpgxfk2zudn/2014-02-01%20at%2016.20.png

Tested on Symbian (Nokia 808) and verified Harmattan builds.
