### PR TITLE
Support both http and https Flickr URLs

### DIFF
--- a/qml/tweetian-harmattan/Services/Flickr.js
+++ b/qml/tweetian-harmattan/Services/Flickr.js
@@ -20,19 +20,27 @@
 .pragma library
 
 var BASE_URL = "http://api.flickr.com/services/rest/"
-var FLICKR_LINK_REGEXP = /http:\/\/(flic\.kr\/p\/\w+|(www\.)?flickr\.com\/photos\/[\w\-\d@]+\/\d+)|https:\/\/secure.flickr\.com\/photos\/[\w\-\d@]+\/\d+/ig
+var FLICKR_LINK_REGEXP = /https?:\/\/(flic\.kr\/p\/\w+|((www\.)?|(secure\.)?)flickr\.com\/photos\/[\w\-\d@]+\/\d+)/ig
 
 var URLS = [ "http://flic.kr/p/",
-             "http://www.flickr.com/photos/",
+             "https://flic.kr/p/",
              "http://flickr.com/photos/",
+             "https://flickr.com/photos/",
+             "http://www.flickr.com/photos/",
+             "https://www.flickr.com/photos/",
+             "http://secure.flickr.com/photos/",
              "https://secure.flickr.com/photos/"
            ]
 
 /**
  * Only the following format of Flickr link will be accepted:
  * - http://flic.kr/p/{base-58-encoded-photo-id}
- * - http://www.flickr.com/photos/{user-id}/{photo-id}
+ * - https://flic.kr/p/{base-58-encoded-photo-id}
  * - http://flickr.com/photos/{user-id}/{photo-id}
+ * - https://flickr.com/photos/{user-id}/{photo-id}
+ * - http://www.flickr.com/photos/{user-id}/{photo-id}
+ * - https://www.flickr.com/photos/{user-id}/{photo-id}
+ * - http://secure.flickr.com/photos/{user-id}/{photo-id}
  * - https://secure.flickr.com/photos/{user-id}/{photo-id}
  */
 function getSizes(constant, link, onSuccess) {
@@ -72,18 +80,20 @@ function getSizes(constant, link, onSuccess) {
 function __getPhotoId(link) {
     var extracted = "";
 
-    if (link.indexOf(URLS[0]) === 0)
-        return __base58Decode(link.substring(URLS[0].length));
-    else if (link.indexOf(URLS[1]) === 0)
-        extracted = link.substring(URLS[1].length);
-    else if (link.indexOf(URLS[2]) === 0)
-        extracted = link.substring(URLS[2].length);
-    else if (link.indexOf(URLS[3]) === 0)
-        extracted = link.substring(URLS[3].length);
-    else
-        throw new Error("Invalid Flickr link: " + link);
-
-    return extracted.substring(extracted.indexOf("/") + 1);
+    for (var i = 0; i < URLS.length; i++) {
+        if (link.indexOf(URLS[i]) === 0) {
+            if (i < 2) {
+            // Short URL
+                return __base58Decode(link.substring(URLS[i].length));
+            } else {
+            // Long URL
+                extracted = link.substring(URLS[i].length);
+                return extracted.substring(extracted.indexOf("/") + 1);
+            }
+        }
+    }
+    // Didn't match anything
+    throw new Error("Invalid Flickr link: " + link);
 }
 
 function __base58Decode( snipcode ) {

--- a/qml/tweetian-harmattan/Services/Twitter.js
+++ b/qml/tweetian-harmattan/Services/Twitter.js
@@ -66,6 +66,7 @@ var POST_RETWEET_URL = "https://api.twitter.com/1.1/statuses/retweet/%1.json"
 var POST_FAVOURITE_URL = "https://api.twitter.com/1.1/favorites/create.json"
 var POST_UNFAVOURITE_URL = "https://api.twitter.com/1.1/favorites/destroy.json"
 var POST_DIRECT_MSG_URL = "https://api.twitter.com/1.1/direct_messages/new.json"
+var POST_BLOCK_USER_URL = "https://api.twitter.com/1.1/blocks/create.json"
 var POST_REPORT_SPAM_URL = "https://api.twitter.com/1.1/users/report_spam.json"
 var POST_SAVED_SEARCHES_URL = "https://api.twitter.com/1.1/saved_searches/create.json"
 var POST_REMOVE_SAVED_SEARCH_URL = "https://api.twitter.com/1.1/saved_searches/destroy/%1.json"
@@ -455,6 +456,15 @@ function postSavedSearches(query, onSuccess, onFailure) {
 function postRemoveSavedSearch(id, onSuccess, onFailure) {
     var removeSearchRequest = new OAuthRequest("POST", POST_REMOVE_SAVED_SEARCH_URL.arg(id + ""))
     removeSearchRequest.sendRequest(onSuccess, onFailure)
+}
+
+function postBlockUser(screenName, onSuccess, onFailure) {
+    var reportSpamRequest = new OAuthRequest("POST", POST_BLOCK_USER_URL)
+    var parameters = [["screen_name", screenName],
+                      ["include_entities", "false"],
+                      ["skip_status", "true"]]
+    reportSpamRequest.setParameters(parameters)
+    reportSpamRequest.sendRequest(onSuccess, onFailure)
 }
 
 function postReportSpam(screenName, onSuccess, onFailure) {

--- a/qml/tweetian-harmattan/UserPage.qml
+++ b/qml/tweetian-harmattan/UserPage.qml
@@ -79,6 +79,11 @@ Page {
                 onClicked: internal.createFollowUserDialog()
             }
             MenuItem {
+                text: qsTr("Block user")
+                enabled: screenName !== settings.userScreenName
+                onClicked: internal.createReportSpamDialog()
+            }
+            MenuItem {
                 text: qsTr("Report user as spammer")
                 enabled: screenName !== settings.userScreenName
                 onClicked: internal.createReportSpamDialog()
@@ -322,6 +327,19 @@ Page {
         function followOnFailure(status, statusText) {
             infoBanner.showHttpError(status, statusText)
             loadingRect.visible = false
+        }
+
+        function reportBlockOnSuccess(data) {
+            infoBanner.showText(qsTr("Blocked %1").arg("@" + data.screen_name))
+            loadingRect.visible = false
+        }
+
+        function createBlockUserDialog() {
+            var message = qsTr("Do you want to block %1?").arg("@" + screenName)
+            dialog.createQueryDialog(qsTr("Block User"), "", message, function() {
+                Twitter.postBlockUser(screenName, reportBlockOnSuccess, reportSpamOnFailure)
+                loadingRect.visible = true
+            })
         }
 
         function reportSpamOnSuccess(data) {

--- a/qml/tweetian-symbian/Services/Flickr.js
+++ b/qml/tweetian-symbian/Services/Flickr.js
@@ -20,19 +20,27 @@
 .pragma library
 
 var BASE_URL = "http://api.flickr.com/services/rest/"
-var FLICKR_LINK_REGEXP = /http:\/\/(flic\.kr\/p\/\w+|(www\.)?flickr\.com\/photos\/[\w\-\d@]+\/\d+)|https:\/\/secure.flickr\.com\/photos\/[\w\-\d@]+\/\d+/ig
+var FLICKR_LINK_REGEXP = /https?:\/\/(flic\.kr\/p\/\w+|((www\.)?|(secure\.)?)flickr\.com\/photos\/[\w\-\d@]+\/\d+)/ig
 
 var URLS = [ "http://flic.kr/p/",
-             "http://www.flickr.com/photos/",
+             "https://flic.kr/p/",
              "http://flickr.com/photos/",
+             "https://flickr.com/photos/",
+             "http://www.flickr.com/photos/",
+             "https://www.flickr.com/photos/",
+             "http://secure.flickr.com/photos/",
              "https://secure.flickr.com/photos/"
            ]
 
 /**
  * Only the following format of Flickr link will be accepted:
  * - http://flic.kr/p/{base-58-encoded-photo-id}
- * - http://www.flickr.com/photos/{user-id}/{photo-id}
+ * - https://flic.kr/p/{base-58-encoded-photo-id}
  * - http://flickr.com/photos/{user-id}/{photo-id}
+ * - https://flickr.com/photos/{user-id}/{photo-id}
+ * - http://www.flickr.com/photos/{user-id}/{photo-id}
+ * - https://www.flickr.com/photos/{user-id}/{photo-id}
+ * - http://secure.flickr.com/photos/{user-id}/{photo-id}
  * - https://secure.flickr.com/photos/{user-id}/{photo-id}
  */
 function getSizes(constant, link, onSuccess) {
@@ -72,18 +80,20 @@ function getSizes(constant, link, onSuccess) {
 function __getPhotoId(link) {
     var extracted = "";
 
-    if (link.indexOf(URLS[0]) === 0)
-        return __base58Decode(link.substring(URLS[0].length));
-    else if (link.indexOf(URLS[1]) === 0)
-        extracted = link.substring(URLS[1].length);
-    else if (link.indexOf(URLS[2]) === 0)
-        extracted = link.substring(URLS[2].length);
-    else if (link.indexOf(URLS[3]) === 0)
-        extracted = link.substring(URLS[3].length);
-    else
-        throw new Error("Invalid Flickr link: " + link);
-
-    return extracted.substring(extracted.indexOf("/") + 1);
+    for (var i = 0; i < URLS.length; i++) {
+        if (link.indexOf(URLS[i]) === 0) {
+            if (i < 2) {
+            // Short URL
+                return __base58Decode(link.substring(URLS[i].length));
+            } else {
+            // Long URL
+                extracted = link.substring(URLS[i].length);
+                return extracted.substring(extracted.indexOf("/") + 1);
+            }
+        }
+    }
+    // Didn't match anything
+    throw new Error("Invalid Flickr link: " + link);
 }
 
 function __base58Decode( snipcode ) {

--- a/qml/tweetian-symbian/Services/Twitter.js
+++ b/qml/tweetian-symbian/Services/Twitter.js
@@ -66,6 +66,7 @@ var POST_RETWEET_URL = "https://api.twitter.com/1.1/statuses/retweet/%1.json"
 var POST_FAVOURITE_URL = "https://api.twitter.com/1.1/favorites/create.json"
 var POST_UNFAVOURITE_URL = "https://api.twitter.com/1.1/favorites/destroy.json"
 var POST_DIRECT_MSG_URL = "https://api.twitter.com/1.1/direct_messages/new.json"
+var POST_BLOCK_USER_URL = "https://api.twitter.com/1.1/blocks/create.json"
 var POST_REPORT_SPAM_URL = "https://api.twitter.com/1.1/users/report_spam.json"
 var POST_SAVED_SEARCHES_URL = "https://api.twitter.com/1.1/saved_searches/create.json"
 var POST_REMOVE_SAVED_SEARCH_URL = "https://api.twitter.com/1.1/saved_searches/destroy/%1.json"
@@ -455,6 +456,15 @@ function postSavedSearches(query, onSuccess, onFailure) {
 function postRemoveSavedSearch(id, onSuccess, onFailure) {
     var removeSearchRequest = new OAuthRequest("POST", POST_REMOVE_SAVED_SEARCH_URL.arg(id + ""))
     removeSearchRequest.sendRequest(onSuccess, onFailure)
+}
+
+function postBlockUser(screenName, onSuccess, onFailure) {
+    var reportSpamRequest = new OAuthRequest("POST", POST_BLOCK_USER_URL)
+    var parameters = [["screen_name", screenName],
+                      ["include_entities", "false"],
+                      ["skip_status", "true"]]
+    reportSpamRequest.setParameters(parameters)
+    reportSpamRequest.sendRequest(onSuccess, onFailure)
 }
 
 function postReportSpam(screenName, onSuccess, onFailure) {

--- a/qml/tweetian-symbian/UserPage.qml
+++ b/qml/tweetian-symbian/UserPage.qml
@@ -102,6 +102,12 @@ Page {
                 onClicked: internal.createFollowUserDialog()
             }
             MenuItem {
+                text: qsTr("Block user")
+                enabled: screenName !== settings.userScreenName
+                platformInverted: userPageMenu.platformInverted
+                onClicked: internal.createBlockUserDialog()
+            }
+            MenuItem {
                 text: qsTr("Report user as spammer")
                 enabled: screenName !== settings.userScreenName
                 platformInverted: userPageMenu.platformInverted
@@ -348,6 +354,19 @@ Page {
         function followOnFailure(status, statusText) {
             infoBanner.showHttpError(status, statusText)
             loadingRect.visible = false
+        }
+
+        function reportBlockOnSuccess(data) {
+            infoBanner.showText(qsTr("Blocked %1").arg("@" + data.screen_name))
+            loadingRect.visible = false
+        }
+
+        function createBlockUserDialog() {
+            var message = qsTr("Do you want to block %1?").arg("@" + screenName)
+            dialog.createQueryDialog(qsTr("Block User"), "", message, function() {
+                Twitter.postBlockUser(screenName, reportBlockOnSuccess, reportSpamOnFailure)
+                loadingRect.visible = true
+            })
         }
 
         function reportSpamOnSuccess(data) {


### PR DESCRIPTION
Flickr have switched to https links by default for flickr.com/photos/ and flic.kr/p/. The http versions are still being used and supported by Flickr. Both http and https work for secure.flickr.com/photos/.

This patch supports both http and https for all Flickr URLs
- Tested on Symbian with a Nokia 808.
- Confirmed Harmattan builds.
- Also includes PR #25 (block user).
