### PR TITLE
Flickr now SSL-only

### DIFF
--- a/qml/tweetian-harmattan/Services/Flickr.js
+++ b/qml/tweetian-harmattan/Services/Flickr.js
@@ -19,7 +19,7 @@
 
 .pragma library
 
-var BASE_URL = "http://api.flickr.com/services/rest/"
+var BASE_URL = "https://api.flickr.com/services/rest/"
 var FLICKR_LINK_REGEXP = /https?:\/\/(flic\.kr\/p\/\w+|((www\.)?|(secure\.)?)flickr\.com\/photos\/[\w\-\d@]+\/\d+)/ig
 
 var URLS = [ "http://flic.kr/p/",

--- a/qml/tweetian-symbian/Services/Flickr.js
+++ b/qml/tweetian-symbian/Services/Flickr.js
@@ -19,7 +19,7 @@
 
 .pragma library
 
-var BASE_URL = "http://api.flickr.com/services/rest/"
+var BASE_URL = "https://api.flickr.com/services/rest/"
 var FLICKR_LINK_REGEXP = /https?:\/\/(flic\.kr\/p\/\w+|((www\.)?|(secure\.)?)flickr\.com\/photos\/[\w\-\d@]+\/\d+)/ig
 
 var URLS = [ "http://flic.kr/p/",


### PR DESCRIPTION
Flickr images weren't being loaded in Tweets because the Flickr API is now SSL-only.

http://code.flickr.net/2014/04/30/flickr-api-going-ssl-only-on-june-27th-2014/

The fix is to simply add a `s` to the `http`.

Tested on Symbian/Nokia 808.
